### PR TITLE
Add read-only indicator for computed env vars

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -185,6 +185,10 @@ func runCLISet(opts Options) bool {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+		if goenv.IsReadOnly(key) {
+			fmt.Fprintf(os.Stderr, "Error: %s is read-only and cannot be set\n", key)
+			os.Exit(1)
+		}
 		if valErr := goenv.ValidateEnvValue(key, value); valErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", valErr.Message)
 		}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -97,9 +97,10 @@ func ReloadEnv() ([]goenv.EnvVar, error) {
 		if v != "" {
 			_, changed := changedVars[k]
 			items = append(items, goenv.EnvVar{
-				Key:     k,
-				Value:   v,
-				Changed: changed,
+				Key:      k,
+				Value:    v,
+				Changed:  changed,
+				ReadOnly: goenv.IsReadOnly(k),
 			})
 		}
 	}

--- a/internal/goenv/descriptions.go
+++ b/internal/goenv/descriptions.go
@@ -51,6 +51,26 @@ func NextCategory(current Category) Category {
 	return "" // unknown category, reset to All
 }
 
+// readOnlyVariables lists environment variables that are computed by Go and
+// cannot be set with 'go env -w'.
+var readOnlyVariables = map[string]struct{}{
+	"GOVERSION":  {},
+	"GOTOOLDIR":  {},
+	"GOMOD":      {},
+	"GOHOSTOS":   {},
+	"GOHOSTARCH": {},
+	"GOEXE":      {},
+	"GOGCCFLAGS": {},
+	"GOENV":      {}, // path to config file; cannot be changed via go env -w
+}
+
+// IsReadOnly returns true if the given environment variable is computed by Go
+// and cannot be set with 'go env -w'.
+func IsReadOnly(key string) bool {
+	_, ok := readOnlyVariables[key]
+	return ok
+}
+
 // envVarCategories maps environment variable names to their categories.
 var envVarCategories = map[string]Category{
 	// General

--- a/internal/goenv/descriptions_test.go
+++ b/internal/goenv/descriptions_test.go
@@ -458,3 +458,35 @@ func TestGetEnvVarCategory_DefaultsToGeneral(t *testing.T) {
 		t.Errorf("unknown var category = %q, want General (default)", cat)
 	}
 }
+
+// --- IsReadOnly Tests ---
+
+func TestIsReadOnly_KnownReadOnlyVars(t *testing.T) {
+	readOnlyVars := []string{
+		"GOVERSION", "GOTOOLDIR", "GOMOD",
+		"GOHOSTOS", "GOHOSTARCH", "GOEXE", "GOGCCFLAGS", "GOENV",
+	}
+	for _, key := range readOnlyVars {
+		if !IsReadOnly(key) {
+			t.Errorf("IsReadOnly(%q) = false, want true", key)
+		}
+	}
+}
+
+func TestIsReadOnly_SettableVars(t *testing.T) {
+	settableVars := []string{
+		"GOPATH", "GOROOT", "GOOS", "GOARCH", "GOPROXY",
+		"CGO_ENABLED", "GOBIN", "GO111MODULE", "GOWORK",
+	}
+	for _, key := range settableVars {
+		if IsReadOnly(key) {
+			t.Errorf("IsReadOnly(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestIsReadOnly_UnknownVar(t *testing.T) {
+	if IsReadOnly("NONEXISTENT_VAR") {
+		t.Error("IsReadOnly(unknown) = true, want false")
+	}
+}

--- a/internal/goenv/envvar.go
+++ b/internal/goenv/envvar.go
@@ -6,4 +6,5 @@ type EnvVar struct {
 	Value    string
 	Changed  bool
 	Favorite bool
+	ReadOnly bool
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -313,6 +313,8 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		newModel, cmd = m.handleChangeScreen(msg)
 	case startEditMsg:
 		newModel, cmd = m.handleStartEdit(msg)
+	case showDetailMsg:
+		newModel, cmd = m.handleShowDetail(msg)
 	case saveEnvRequestMsg:
 		newModel, cmd = m.handleSaveEnvRequest(msg)
 	case envSetSuccessMsg:

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -74,8 +74,11 @@ func (d envVarDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 		descStyle = d.Styles.NormalDesc.Width(width)
 	}
 
-	// Render title (variable name) with optional category tag and change indicator
+	// Render title (variable name) with optional category tag, read-only tag, and change indicator
 	title := ei.Title()
+	if ei.ReadOnly {
+		title = readOnlyLabelStyle.Render("[RO]") + " " + title
+	}
 	if tag := d.categoryTag(m, index, ei); tag != "" {
 		title = categoryLabelStyle.Render(tag) + " " + title
 	}

--- a/internal/tui/editscreen.go
+++ b/internal/tui/editscreen.go
@@ -12,6 +12,8 @@ import (
 
 // EditScreenModel provides a text input for editing a selected environment variable.
 // It displays the original value and tracks length changes during editing.
+// When readOnly is true, the text input is disabled and the screen shows
+// variable details without allowing modification.
 type EditScreenModel struct {
 	textInput       textinput.Model
 	editingKey      string
@@ -21,6 +23,7 @@ type EditScreenModel struct {
 	showSuggestions bool
 	validationError string // Current validation error message, if any
 	goVersion       goenv.GoVersion
+	readOnly        bool
 }
 
 // NewEditScreenModel creates a new edit screen with default text input configuration.
@@ -67,17 +70,36 @@ func (m *EditScreenModel) updateSuggestions() {
 }
 
 // Init initializes the edit screen by focusing the text input and starting cursor blink.
+// In read-only mode, the text input is not focused and no cursor blink is started.
 func (m *EditScreenModel) Init() tea.Cmd {
-	m.textInput.Focus()
 	m.suggestionIdx = -1
 	m.showSuggestions = true
 	m.validationError = ""
+	if m.readOnly {
+		m.textInput.Blur()
+		return nil
+	}
+	m.textInput.Focus()
 	m.updateSuggestions()
 	return textinput.Blink
 }
 
 // Update handles messages for the edit screen, including Enter to save and Esc to cancel.
+// In read-only mode, only Esc (back) and copy keys (y/Y) are handled.
 func (m *EditScreenModel) Update(msg tea.Msg) tea.Cmd {
+	if m.readOnly {
+		if msg, ok := msg.(tea.KeyPressMsg); ok {
+			switch msg.String() {
+			case "esc":
+				return sendMsg(changeScreenMsg(AppScreenList))
+			case "y":
+				return sendMsg(copyValueMsg{Key: m.editingKey, Value: m.originalValue})
+			case "Y":
+				return sendMsg(copyKeyValueMsg{Key: m.editingKey, Value: m.originalValue})
+			}
+		}
+		return nil
+	}
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch msg.String() {
@@ -161,7 +183,11 @@ func (m *EditScreenModel) Update(msg tea.Msg) tea.Cmd {
 
 // View renders the edit screen with the variable name, visual diff,
 // text input, suggestions, length information, and keyboard hints.
+// In read-only mode, it shows the value as plain text with description and docs.
 func (m EditScreenModel) View() string {
+	if m.readOnly {
+		return m.readOnlyView()
+	}
 	currentValue := m.textInput.Value()
 	currentLen := len(currentValue)
 	originalLen := len(m.originalValue)
@@ -274,6 +300,28 @@ func (m EditScreenModel) renderCSVBreakdown() string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// readOnlyView renders the read-only detail view for a variable.
+func (m EditScreenModel) readOnlyView() string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("%s %s (read-only)", IconReadOnly, m.editingKey))
+
+	parts = append(parts, editOriginalValueStyle.Render(fmt.Sprintf("Value: %s", m.originalValue)))
+
+	if desc := goenv.GetEnvVarDescription(m.editingKey); desc != "" {
+		parts = append(parts, editDocStyle.Render(desc))
+	}
+
+	if doc := goenv.GetExtendedDoc(m.editingKey); doc != "" {
+		parts = append(parts, editDocStyle.Render(doc))
+	}
+
+	parts = append(parts, editLengthInfoStyle.Render(fmt.Sprintf("Length: %d", len(m.originalValue))))
+
+	parts = append(parts, readOnlyHelpText)
+
+	return strings.Join(parts, "\n\n")
 }
 
 // renderDiff creates a visual comparison between original and new values.

--- a/internal/tui/editscreen_test.go
+++ b/internal/tui/editscreen_test.go
@@ -221,3 +221,105 @@ func TestEditScreen_View_ContainsEditingKey(t *testing.T) {
 		t.Error("view should contain the editing key name")
 	}
 }
+
+// --- Read-Only Mode Tests ---
+
+func TestEditScreen_ReadOnly_InitDoesNotFocus(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	cmd := m.Init()
+
+	if cmd != nil {
+		t.Error("read-only Init should return nil (no blink)")
+	}
+}
+
+func TestEditScreen_ReadOnly_EscReturnsToList(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	m.Init()
+
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected command from Esc in read-only mode")
+	}
+	msg := cmd()
+	if csm, ok := msg.(changeScreenMsg); !ok || AppScreen(csm) != AppScreenList {
+		t.Errorf("expected changeScreenMsg(AppScreenList), got %T", msg)
+	}
+}
+
+func TestEditScreen_ReadOnly_IgnoresEnterAndTyping(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	m.Init()
+
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("read-only mode should ignore Enter key")
+	}
+
+	cmd = m.Update(tea.KeyPressMsg{Code: 'a'})
+	if cmd != nil {
+		t.Error("read-only mode should ignore character input")
+	}
+}
+
+func TestEditScreen_ReadOnly_CopyValueKey(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	m.Init()
+
+	cmd := m.Update(tea.KeyPressMsg{Code: 'y'})
+	if cmd == nil {
+		t.Fatal("expected command from y in read-only mode")
+	}
+	msg := cmd()
+	if cvm, ok := msg.(copyValueMsg); !ok || cvm.Key != "GOVERSION" {
+		t.Errorf("expected copyValueMsg for GOVERSION, got %T", msg)
+	}
+}
+
+func TestEditScreen_ReadOnly_CopyKeyValueKey(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	m.Init()
+
+	cmd := m.Update(tea.KeyPressMsg{Code: 'Y'})
+	if cmd == nil {
+		t.Fatal("expected command from Y in read-only mode")
+	}
+	msg := cmd()
+	if ckvm, ok := msg.(copyKeyValueMsg); !ok || ckvm.Key != "GOVERSION" {
+		t.Errorf("expected copyKeyValueMsg for GOVERSION, got %T", msg)
+	}
+}
+
+func TestEditScreen_ReadOnly_ViewShowsReadOnlyLabel(t *testing.T) {
+	m := NewEditScreenModel(goenv.GoVersion{Major: 1, Minor: 21, Patch: 0})
+	m.editingKey = "GOVERSION"
+	m.originalValue = "go1.21.0"
+	m.readOnly = true
+	m.Init()
+
+	view := m.View()
+	if !strings.Contains(view, "read-only") {
+		t.Error("read-only view should contain 'read-only' label")
+	}
+	if !strings.Contains(view, "GOVERSION") {
+		t.Error("read-only view should contain the variable name")
+	}
+	if !strings.Contains(view, "go1.21.0") {
+		t.Error("read-only view should contain the value")
+	}
+}

--- a/internal/tui/handlers.go
+++ b/internal/tui/handlers.go
@@ -100,6 +100,20 @@ func (m mainModel) handleStartEdit(msg startEditMsg) (mainModel, tea.Cmd) {
 	m.editScreen.editingKey = itemToEdit.Key
 	m.editScreen.originalValue = itemToEdit.Value
 	m.editScreen.textInput.SetValue(itemToEdit.Value)
+	m.editScreen.readOnly = false
+	m.currentScreen = AppScreenEdit
+	m.clearTempMessages()
+	m.calculateScreenSizes()
+	return m, m.editScreen.Init()
+}
+
+// handleShowDetail handles transitioning to the read-only detail view for a variable.
+func (m mainModel) handleShowDetail(msg showDetailMsg) (mainModel, tea.Cmd) {
+	ev := goenv.EnvVar(msg)
+	m.editScreen.editingKey = ev.Key
+	m.editScreen.originalValue = ev.Value
+	m.editScreen.textInput.SetValue(ev.Value)
+	m.editScreen.readOnly = true
 	m.currentScreen = AppScreenEdit
 	m.clearTempMessages()
 	m.calculateScreenSizes()
@@ -549,6 +563,9 @@ func (m mainModel) handleShowCommandPalette() (mainModel, tea.Cmd) {
 func (m mainModel) handleCommandPaletteEdit() (mainModel, tea.Cmd) {
 	m.currentScreen = AppScreenList
 	if ei, ok := m.selectedEnvItem(); ok {
+		if ei.ReadOnly {
+			return m, sendMsg(showDetailMsg(ei.EnvVar))
+		}
 		return m, sendMsg(startEditMsg(ei.EnvVar))
 	}
 	return m, m.refreshListScreen()
@@ -584,7 +601,7 @@ func (m mainModel) handleCommandPaletteFavorite() (mainModel, tea.Cmd) {
 // handleCommandPaletteReset handles the "reset" command from the palette.
 func (m mainModel) handleCommandPaletteReset() (mainModel, tea.Cmd) {
 	m.currentScreen = AppScreenList
-	if ei, ok := m.selectedEnvItem(); ok && ei.Changed {
+	if ei, ok := m.selectedEnvItem(); ok && !ei.ReadOnly && ei.Changed {
 		return m, sendMsg(resetEnvMsg{Key: ei.Key})
 	}
 	return m, m.refreshListScreen()

--- a/internal/tui/helpscreen.go
+++ b/internal/tui/helpscreen.go
@@ -38,7 +38,7 @@ func (m HelpScreenModel) View() string {
 	content += helpKeyStyle.Render("Ctrl+U") + helpDescStyle.Render("Half-page up") + "\n"
 	content += helpKeyStyle.Render("g/G") + helpDescStyle.Render("Go to top/bottom") + "\n"
 	content += helpKeyStyle.Render("/") + helpDescStyle.Render("Search/filter variables") + "\n"
-	content += helpKeyStyle.Render("Enter") + helpDescStyle.Render("Edit selected variable") + "\n"
+	content += helpKeyStyle.Render("Enter") + helpDescStyle.Render("Edit variable (view details if [RO])") + "\n"
 	content += helpKeyStyle.Render("q") + helpDescStyle.Render("Quit") + "\n"
 
 	content += "\n" + helpSectionStyle.Render("Actions") + "\n"
@@ -72,6 +72,10 @@ func (m HelpScreenModel) View() string {
 	content += helpKeyStyle.Render("Ctrl+R") + helpDescStyle.Render("Reset to original value") + "\n"
 	content += helpKeyStyle.Render("Tab") + helpDescStyle.Render("Next suggestion") + "\n"
 	content += helpKeyStyle.Render("Shift+Tab") + helpDescStyle.Render("Previous suggestion") + "\n"
+
+	content += "\n" + helpSectionStyle.Render("Read-Only Variables") + "\n"
+	content += helpDescStyle.Render("Variables marked [RO] are computed by Go and cannot") + "\n"
+	content += helpDescStyle.Render("be changed. Press Enter to view details, y/Y to copy.") + "\n"
 
 	content += "\n" + helpFooterStyle.Render(helpScreenFooter)
 

--- a/internal/tui/listscreen.go
+++ b/internal/tui/listscreen.go
@@ -104,6 +104,9 @@ func (m *ListScreenModel) Update(msg tea.Msg) tea.Cmd {
 		switch msg.String() {
 		case "enter":
 			if selectedItem, ok := m.list.SelectedItem().(envItem); ok {
+				if selectedItem.ReadOnly {
+					return sendMsg(showDetailMsg(selectedItem.EnvVar))
+				}
 				return sendMsg(startEditMsg(selectedItem.EnvVar))
 			}
 		case "s":
@@ -144,9 +147,9 @@ func (m *ListScreenModel) Update(msg tea.Msg) tea.Cmd {
 			// Show stats (Shift+S)
 			return sendMsg(showStatsMsg{})
 		case "u":
-			// Reset current variable to default
+			// Reset current variable to default (not available for read-only vars)
 			if selectedItem, ok := m.list.SelectedItem().(envItem); ok {
-				if selectedItem.Changed {
+				if !selectedItem.ReadOnly && selectedItem.Changed {
 					return sendMsg(resetEnvMsg{Key: selectedItem.Key})
 				}
 			}

--- a/internal/tui/listscreen_test.go
+++ b/internal/tui/listscreen_test.go
@@ -130,3 +130,40 @@ func TestListScreen_InitReturnsNil(t *testing.T) {
 		t.Error("Init should return nil")
 	}
 }
+
+func TestListScreen_EnterOnReadOnlySendsShowDetailMsg(t *testing.T) {
+	items := []list.Item{
+		envItem{goenv.EnvVar{Key: "GOVERSION", Value: "go1.21.0", ReadOnly: true}},
+		envItem{goenv.EnvVar{Key: "GOPATH", Value: "/go"}},
+	}
+	m := NewListScreenModelWithSortMode(items, "go1.21.0", goenv.GoVersion{Major: 1, Minor: 21, Patch: 0}, persist.SortAlpha, nil)
+	m.list.SetSize(80, 24)
+	m.list.Select(0)
+
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from Enter key on read-only item")
+	}
+	msg := cmd()
+	if _, ok := msg.(showDetailMsg); !ok {
+		t.Errorf("expected showDetailMsg for read-only item, got %T", msg)
+	}
+}
+
+func TestListScreen_EnterOnSettableSendsStartEditMsg(t *testing.T) {
+	items := []list.Item{
+		envItem{goenv.EnvVar{Key: "GOPATH", Value: "/go", ReadOnly: false}},
+	}
+	m := NewListScreenModelWithSortMode(items, "go1.21.0", goenv.GoVersion{Major: 1, Minor: 21, Patch: 0}, persist.SortAlpha, nil)
+	m.list.SetSize(80, 24)
+	m.list.Select(0)
+
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from Enter key on settable item")
+	}
+	msg := cmd()
+	if _, ok := msg.(startEditMsg); !ok {
+		t.Errorf("expected startEditMsg for settable item, got %T", msg)
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -92,6 +92,9 @@ type changeScreenMsg AppScreen
 // startEditMsg is sent from a screen model to initiate editing a specific variable.
 type startEditMsg goenv.EnvVar
 
+// showDetailMsg is sent to view a read-only variable's details without editing.
+type showDetailMsg goenv.EnvVar
+
 // toggleSortMsg requests toggling the sort mode.
 type toggleSortMsg struct{}
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -75,6 +75,7 @@ var (
 var (
 	favoriteStarStyle  lipgloss.Style
 	categoryLabelStyle lipgloss.Style
+	readOnlyLabelStyle lipgloss.Style
 )
 
 var inlineDescStyle lipgloss.Style
@@ -213,6 +214,10 @@ func regenerateStyles() {
 		Foreground(activeTheme.CategoryLabel).
 		Italic(true)
 
+	readOnlyLabelStyle = lipgloss.NewStyle().
+		Foreground(colorDim).
+		Italic(true)
+
 	// Inline description style (shown under selected item)
 	inlineDescStyle = lipgloss.NewStyle().
 		Foreground(colorAccent).
@@ -235,6 +240,7 @@ const (
 	inputPrompt      = "> "
 	inputPlaceholder = "Enter new value..."
 	editHelpText     = "(Enter: save, Esc: cancel, Ctrl+R: reset)"
+	readOnlyHelpText = "(y: copy value, Y: copy KEY=VALUE, Esc: back)"
 	listHelpText     = "Press Enter to edit, 'q' or Ctrl+C to quit"
 	helpScreenTitle  = "GO ENV - Keyboard Shortcuts"
 	helpScreenFooter = "Press Esc, q, or ? to return..."
@@ -249,4 +255,5 @@ const (
 	IconReload   = "\u21BB"
 	IconFavorite = "\u2605"
 	IconWatch    = "\u2299"
+	IconReadOnly = "\U0001F512"
 )

--- a/internal/tui/tuicmds.go
+++ b/internal/tui/tuicmds.go
@@ -127,10 +127,14 @@ func performExportCmd(name, description string, items []goenv.EnvVar) tea.Cmd {
 }
 
 // performImportApplyCmd creates a command that applies imported variables.
+// Read-only variables are silently skipped.
 func performImportApplyCmd(variables []goenv.EnvVar) tea.Cmd {
 	return func() tea.Msg {
 		var successCount, failedCount int
 		for _, ev := range variables {
+			if goenv.IsReadOnly(ev.Key) {
+				continue
+			}
 			if err := commands.SetEnvVar(ev); err != nil {
 				failedCount++
 			} else {


### PR DESCRIPTION
## Summary
- Mark computed/toolchain-derived env vars as read-only with a lock icon in the list view
- Show an informational message instead of opening the edit screen for read-only vars
- Add `ReadOnly` field to `EnvVar` and `IsReadOnly()` lookup in the domain layer
- Update CLI, TUI delegate, edit screen, list screen, help screen, and styles

Closes #2

## Test plan
- [x] `mise run test` passes (all packages)
- [x] Read-only vars (e.g. `GOVERSION`, `GOTOOLDIR`) show lock icon in list
- [x] Pressing Enter on a read-only var shows info message, not edit screen
- [x] Editable vars still open the edit screen normally